### PR TITLE
feat(Dockerfile): get rid of heroku, install gcloud

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -8,9 +8,17 @@ RUN apt-get update \
     fortune \
     fortunes \
     sl \
-  && curl https://cli-assets.heroku.com/install-ubuntu.sh | sh \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
+
+ARG CLOUD_SDK_VERSION=403.0.0
+
+# Install the gcloud sdk.
+RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz \
+  && tar xzf google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz \
+  && rm google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz
+
+ENV PATH /google-cloud-sdk/bin:$PATH
 
 # Allow "funny" commands to be used from default PATH
 RUN for cli in /usr/games/*;do ln -s "$cli" /usr/local/bin/;done \


### PR DESCRIPTION
### What does this PR do?

This PR sets up the gcloud SDK in the gitpod environment, and also gets rid of heroku, beause we don't need it anymore.

Relates to https://github.com/cicd-lectures/slides/issues/89